### PR TITLE
Pin to same plexapi version as HA

### DIFF
--- a/custom_components/plex_assistant/manifest.json
+++ b/custom_components/plex_assistant/manifest.json
@@ -8,6 +8,6 @@
     "gTTs",
     "pychromecast==4.1.1",
     "fuzzywuzzy==0.16.0",
-    "git+https://github.com/pkkid/python-plexapi.git@c3e16b2d369968433048ae9a5678294041eb084d#plexapi==9.9.9"
+    "plexapi==3.4.0"
   ]
 }


### PR DESCRIPTION
The version of `plexapi` needs to be in sync with the built-in Plex integration used by Home Assistant. There are conflicts with the current commit both with old and new released versions of the library.

This pins the `plexapi` version to the same one used by HA as of 0.109.0.