### PR TITLE
Update manifest

### DIFF
--- a/custom_components/plex_assistant/manifest.json
+++ b/custom_components/plex_assistant/manifest.json
@@ -6,7 +6,7 @@
   "codeowners": ["@maykar"],
   "requirements": [
     "gTTs",
-    "pychromecast==4.1.1",
+    "pychromecast==5.0.0",
     "fuzzywuzzy==0.16.0",
     "plexapi==3.4.0"
   ]


### PR DESCRIPTION
HA is using pychromecast 5.0.0 and this requirement is causing chromecasts not to load. This is just a version bump to match HA.