### PR TITLE
Update Swedish keywords for localize.py

### DIFF
--- a/custom_components/plex_assistant/localize.py
+++ b/custom_components/plex_assistant/localize.py
@@ -652,6 +652,7 @@ translations = {
         "season": {
             "keywords": [
                 "season",
+                "säsong",
             ],
             "pre": [
                 "a",
@@ -665,6 +666,8 @@ translations = {
         "episode": {
             "keywords": [
                 "episod",
+                "avsnitt",
+                "episode",
             ],
             "pre": [
                 "a",


### PR DESCRIPTION
The swedish word for season is "säsong" added that so u can say both. Added more common swedish word for episode "avsnitt" and also english word as Google assistant picked up "episode" when I said "episod".